### PR TITLE
Refactor protocols to get rid of SynchronizableType

### DIFF
--- a/Synchronizable.xcodeproj/project.pbxproj
+++ b/Synchronizable.xcodeproj/project.pbxproj
@@ -368,6 +368,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = Synchronizable/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -388,6 +392,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = Synchronizable/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/Synchronizable/Synchronizable.swift
+++ b/Synchronizable/Synchronizable.swift
@@ -22,7 +22,7 @@ extension Identifiable {
 protocol Synchronizable: Identifiable {
     associatedtype PersistedType: Persistable
 
-    func comparison(against persistable: PersistedType) -> Diff<Self>
+    func compare(against persistable: PersistedType) -> Diff<Self>
 }
 
 protocol Persistable: Identifiable {
@@ -60,7 +60,7 @@ extension Diff {
                 }
 
                 if let persisted = persistables.filter({ synchronized.isEqual(to: $0) }).first {
-                    return synchronized.comparison(against: persisted)
+                    return synchronized.compare(against: persisted)
                 }
 
                 return .None

--- a/Synchronizable/Synchronizable.swift
+++ b/Synchronizable/Synchronizable.swift
@@ -47,19 +47,19 @@ enum Diff<S: Synchronizable> {
 
 extension Diff {
 
-    static func reducer<P: Persistable, S: Synchronizable where S.PersistedType == P>(local persistables: [P], remote synchronizables: [S]) -> [Diff<S>] {
-        let persistedIds = Set(persistables.map { $0.identifier })
-        let synchronizedIds = Set(synchronizables.map { $0.identifier })
+    static func reducer<P: Persistable, S: Synchronizable where S.PersistedType == P>(local: [P], remote: [S]) -> [Diff<S>] {
+        let persistedIds = Set(local.map { $0.identifier })
+        let synchronizedIds = Set(remote.map { $0.identifier })
 
         let deleted: [Diff<S>] = persistedIds.subtract(synchronizedIds).map { .Delete(identifier: $0) }
 
-        return deleted + synchronizables
+        return deleted + remote
             .map { synchronized in
                 if !persistedIds.contains(synchronized.identifier) {
                     return .Insert(synchronized)
                 }
 
-                if let persisted = persistables.filter({ synchronized.isEqual(to: $0) }).first {
+                if let persisted = local.filter({ synchronized.isEqual(to: $0) }).first {
                     return synchronized.compare(against: persisted)
                 }
 

--- a/SynchronizableTests/DiffReducerSpec.swift
+++ b/SynchronizableTests/DiffReducerSpec.swift
@@ -14,18 +14,18 @@ class DiffReducerSpec: QuickSpec {
     
     override func spec() {
         describe("The Diff Reducer") {
-            let synchronizables: [SynchronizableType] = (0..<10)
+            let synchronizables: [GithubRepository] = (0..<10)
                 .map { ("repository\($0)", $0 < 5 ? "updated" : "not-updated" ) }
                 .map(GithubRepository.init)
 
-            let persistables: [Persistable] = (3..<12)
+            let persistables: [Repository] = (3..<12)
                 .map { ("repository\($0)", "not-updated") }
                 .map(Repository.init)
 
             context("When the persistence store is empty") {
 
                 describe("the resulting diff array") {
-                    let result = Diff.reducer(local: [], remote: synchronizables)
+                    let result = Diff<GithubRepository>.reducer(local: [], remote: synchronizables)
 
                     it("should contain as much elements as the synchronizable input") {
                         expect(result.count).to(equal(synchronizables.count))
@@ -55,7 +55,7 @@ class DiffReducerSpec: QuickSpec {
 
             context("When the persistence store contains Persistables") {
                 describe("the resulting diff array") {
-                    let result = Diff.reducer(local: persistables, remote: synchronizables)
+                    let result = Diff<GithubRepository>.reducer(local: persistables, remote: synchronizables)
                     let freqs = frequencies(result) { $0.key }
 
                     let identifiers = Set(persistables.map { $0.identifier } + synchronizables.map { $0.identifier })
@@ -73,8 +73,8 @@ class DiffReducerSpec: QuickSpec {
                         let filtered = result.filter { $0.isInsert }
 
                         let match: Bool = filtered.reduce(true) { acc, diff in
-                            guard case .Insert(let synchronizable) = diff, let lhs = synchronizable as? GithubRepository else { return false }
-                            let rhs = inserted.filter { $0.identifier == lhs.identifier }.first as! GithubRepository
+                            guard case .Insert(let lhs) = diff else { return false }
+                            let rhs = inserted.filter { $0.identifier == lhs.identifier }.first!
                             return acc && rhs.head == lhs.head
                         }
 
@@ -91,8 +91,8 @@ class DiffReducerSpec: QuickSpec {
                         let filtered = result.filter { $0.isUpdate }
 
                         let match: Bool = filtered.reduce(true) { acc, diff in
-                            guard case .Update(let synchronizable) = diff, let lhs = synchronizable as? GithubRepository else { return false }
-                            let rhs = updated.filter { $0.identifier == lhs.identifier }.first as! GithubRepository
+                            guard case .Update(let lhs) = diff else { return false }
+                            let rhs = updated.filter { $0.identifier == lhs.identifier }.first!
                             return acc && rhs.head == lhs.head
                         }
 

--- a/SynchronizableTests/DiffReducerSpec.swift
+++ b/SynchronizableTests/DiffReducerSpec.swift
@@ -25,7 +25,7 @@ class DiffReducerSpec: QuickSpec {
             context("When the persistence store is empty") {
 
                 describe("the resulting diff array") {
-                    let result = Diff<GithubRepository>.reducer(local: [], remote: synchronizables)
+                    let result = Diff<GithubRepository>.reducer([], remote: synchronizables)
 
                     it("should contain as much elements as the synchronizable input") {
                         expect(result.count).to(equal(synchronizables.count))
@@ -55,7 +55,7 @@ class DiffReducerSpec: QuickSpec {
 
             context("When the persistence store contains Persistables") {
                 describe("the resulting diff array") {
-                    let result = Diff<GithubRepository>.reducer(local: persistables, remote: synchronizables)
+                    let result = Diff<GithubRepository>.reducer(persistables, remote: synchronizables)
                     let freqs = frequencies(result) { $0.key }
 
                     let identifiers = Set(persistables.map { $0.identifier } + synchronizables.map { $0.identifier })

--- a/SynchronizableTests/FrequenciesSpec.swift
+++ b/SynchronizableTests/FrequenciesSpec.swift
@@ -41,7 +41,7 @@ class FrequenciesSpec: QuickSpec {
         }
 
         context("When applied on a collection of Diff") {
-            let diffs: [Diff] = [
+            let diffs: [Diff<GithubRepository>] = [
                 .Insert(GithubRepository(identifier: "ReactiveCocoa", head: "qwertyu")),
                 .Insert(GithubRepository(identifier: "RxSwift", head: "qwertyu")),
                 .Update(GithubRepository(identifier: "Synchronizable", head: "qwertyu")),

--- a/SynchronizableTests/TestModels.swift
+++ b/SynchronizableTests/TestModels.swift
@@ -10,10 +10,12 @@ import Foundation
 @testable import Synchronizable
 
 struct GithubRepository: Synchronizable {
+    typealias PersistedType = Repository
+    
     let identifier: String
     let head: String
 
-    func comparison(against persisted: Repository) -> Diff {
+    func comparison(against persisted: Repository) -> Diff<GithubRepository> {
         guard persisted.head == head else { return .Update(self) }
 
         return .None

--- a/SynchronizableTests/TestModels.swift
+++ b/SynchronizableTests/TestModels.swift
@@ -15,7 +15,7 @@ struct GithubRepository: Synchronizable {
     let identifier: String
     let head: String
 
-    func comparison(against persisted: Repository) -> Diff<GithubRepository> {
+    func compare(against persisted: Repository) -> Diff<GithubRepository> {
         guard persisted.head == head else { return .Update(self) }
 
         return .None


### PR DESCRIPTION
I tried implemented some kind of store that would bind the persisted content with the content
coming from a source of truth. It started well...

<img width="992" alt="messages image 4082149297" src="https://cloud.githubusercontent.com/assets/48797/18458778/01c5461e-7932-11e6-94aa-7ffe4cde1877.png">

... but the `SynchronizedType` was loosing the associated `PersistedType` which made it hard
to use the Diff reducer. I'm fairly confident loosing the `SynchronizedType` should make things
easier.  